### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to this project will be documented in this file.
 - BREAKING Made `Composition` non-public.
 - BREAKING Removed `DockerTest::add_composition`. Use
   `DockerTest::provide_container` instead.
+- Upgrade all dependencies, notable:
+  - tokio from 1.19 to 1.29
+  - bollard from 0.13 to 0.14
 
 ## 0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,124 +1,149 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
 ### Added
-- Added new mechanism to construct Compositions, which are now private. The trait
-    `ContainerSpecification` is implemented for each struct that represent a different lifecycle
-    management mode for the container it specifies. Thus, providing a `StaticManagement` mode is
-    no longer directly exposed, but indirectly through the four container specifications:
-    `TestBodyContainer`(normal), `TestSuiteContainer`(internal), `DynamicContainer`(dynamic),
-    and `ExternalContainer`(external).
+
+- Added new mechanism to construct Compositions, which are now private. The
+  trait `ContainerSpecification` is implemented for each struct that represent a
+  different lifecycle management mode for the container it specifies. Thus,
+  providing a `StaticManagement` mode is no longer directly exposed, but
+  indirectly through the four container specifications:
+  `TestBodyContainer`(normal), `TestSuiteContainer`(internal),
+  `DynamicContainer`(dynamic), and `ExternalContainer`(external).
 - Added `DockerTest::provide_container(c: impl ContainerSpecification)`.
 - Added support for privileged containers.
 
 ### Changed
+
 - BREAKING `WaitFor` now has a `Debug` trait bound.
 - BREAKING Made `Composition` non-public.
-- BREAKING Removed `DockerTest::add_composition`. Use `DockerTest::provide_container` instead.
+- BREAKING Removed `DockerTest::add_composition`. Use
+  `DockerTest::provide_container` instead.
 
 ## 0.3
 
 ### Added
-- Added support for static containers that can be used across multiple tests, both internally
-    and externally managed.
+
+- Added support for static containers that can be used across multiple tests,
+  both internally and externally managed.
 - Added support for capturing container logs. This is configurable through
-    `Composition::with_log_options`.
-- Added support to run on an existing docker network. This is configurable through
-    `DockerTest::with_external_network`.
-- Added support for container network aliases. This is configurable through `Composition::with_alias`
-    and `Composition::alias`.
-- Added `Composition::publish_all_ports` to publish all exposed ports of a container on an
-    ephemeral host port.
-- Added optional `tls` feature which when enabled and combined with setting the `DOCKER_TLS_VERIFY`
-    env variable the connection with the docker daemon is done via TLS over tcp.
+  `Composition::with_log_options`.
+- Added support to run on an existing docker network. This is configurable
+  through `DockerTest::with_external_network`.
+- Added support for container network aliases. This is configurable through
+  `Composition::with_alias` and `Composition::alias`.
+- Added `Composition::publish_all_ports` to publish all exposed ports of a
+  container on an ephemeral host port.
+- Added optional `tls` feature which when enabled and combined with setting the
+  `DOCKER_TLS_VERIFY` env variable the connection with the docker daemon is done
+  via TLS over tcp.
 
 ### Changed
-- BREAKING Added support for custom docker registries. You may now specify a `Source`
-    (renamed from `Remote`).
-    Supplying `Source::RegistryWithDockerLogin` will extract the appropriate login token from the
-    dockerd daemon credentials file, appropriate to the registry you are attempting to pull
-    an image from. If `Source::RegistryWithCredentials` is used, you may specify the appropriate
-    registry address, username, and password directly.
-- BREAKING: `PullPolicy` is now specified on an `Image`, not the `Remote` (now `Source`) variant.
-- BREAKING: `RunningContainer.ports` changed and renamed to `RunningContainer.host_port`.
-    A specific port mapping can now be retrieved instead of all of them.
+
+- BREAKING Added support for custom docker registries. You may now specify a
+  `Source` (renamed from `Remote`). Supplying `Source::RegistryWithDockerLogin`
+  will extract the appropriate login token from the dockerd daemon credentials
+  file, appropriate to the registry you are attempting to pull an image from. If
+  `Source::RegistryWithCredentials` is used, you may specify the appropriate
+  registry address, username, and password directly.
+- BREAKING: `PullPolicy` is now specified on an `Image`, not the `Remote` (now
+  `Source`) variant.
+- BREAKING: `RunningContainer.ports` changed and renamed to
+  `RunningContainer.host_port`. A specific port mapping can now be retrieved
+  instead of all of them.
 
 ### Fixed
+
 - Anonymous volumes are now cleaned up during teardown.
 
 ## 0.2.1
 
 ### Changed
+
 - Upgrade tokio from 0.2 to 1.2
 - Upgrade bollard from 0.8 t0 0.10
 
 ## 0.2.0
 
 ### Added
-- Ability to communicate with containers when dockertest is ran within a docker container environment.
-- Added host port mapping support. Usecase is for Windows where intra-container communication is not feasable with the same API used on Linux.
+
+- Ability to communicate with containers when dockertest is ran within a docker
+  container environment.
+- Added host port mapping support. Usecase is for Windows where intra-container
+  communication is not feasable with the same API used on Linux.
 
 ### Changed
+
 - Upgraded to bollard 0.8
 - Fixed compiling on stable
 - BREAKING: Reworked volume API
 - Container id generation is now all lowercase.
-- BREAKING: Set container ip to localhost when running under windows. Network support is lacking on Windows.
+- BREAKING: Set container ip to localhost when running under windows. Network
+  support is lacking on Windows.
 - Documentation clarifications and spelling errors.
 
 ### Removed
+
 - Diesel dev-dependency.
 
 ## 0.1.2
 
 ### Added
-- Ability to conditionally build docker test images used for running DockerTest's own test suite.
+
+- Ability to conditionally build docker test images used for running
+  DockerTest's own test suite.
 
 ## 0.1.1
 
 ### Added
-- `DockerTest::run` now has an async version: `DockerTest::run_async`.
-    This allows us to run async tests that are already scheduled on a runtime, e.g. async tests
-    annotated with `#[tokio::test]`.
+
+- `DockerTest::run` now has an async version: `DockerTest::run_async`. This
+  allows us to run async tests that are already scheduled on a runtime, e.g.
+  async tests annotated with `#[tokio::test]`.
 
 ## 0.1
 
 ### Added
-- `DockerTest::source()` is now puplic.
-- `RunningContainer::assert_message()` allows one to assert a log outputs presence in the test body.
-- `Composition::inject_container_name()` to inject the generated container name as an environmental
-    variable for in other containers through its handle.
-- Every `DockerTest` instance is ran in its own docker network.
-- Control the teardown process of a test through the environmental variable `DOCKERTEST_PRUNE`.
-    By setting this to one of the following values:
-    * "always": [default] remove everything
-    * "never": leave all containers running
-    * "stop_on_failure": stop containers on execution failure
-    * "running_on_failure": leave containers running on execution failure
 
-    This allows us to more easily debug and inspect test failures by leaving the containers
-    stopped/running.
+- `DockerTest::source()` is now puplic.
+- `RunningContainer::assert_message()` allows one to assert a log outputs
+  presence in the test body.
+- `Composition::inject_container_name()` to inject the generated container name
+  as an environmental variable for in other containers through its handle.
+- Every `DockerTest` instance is ran in its own docker network.
+- Control the teardown process of a test through the environmental variable
+  `DOCKERTEST_PRUNE`. By setting this to one of the following values:
+  - "always": [default] remove everything
+  - "never": leave all containers running
+  - "stop_on_failure": stop containers on execution failure
+  - "running_on_failure": leave containers running on execution failure
+
+  This allows us to more easily debug and inspect test failures by leaving the
+  containers stopped/running.
 
 ### Changed
+
 - BREAKING: `FnOnce` argument to `DockerTest::run` changed its return type to
-    `Future<Output = ()> + Send + 'static`.
-    This entails that the inline close must be a single async block.
-    ```
-    test.run(|ops| async move {
-        assert!(true);
-    });
-    ```
-- BREAKING: `FnOnce` argument to `DockerTest::run` changed its provided arguments to an owned
-    variant of `DockerOperations`.
-- BREAKING: `DockerOperations.handle()` changed to panicking method, directly returning a
-    `RunningContainer` instead of a `Result`.
+  `Future<Output = ()> + Send + 'static`. This entails that the inline close
+  must be a single async block.
+  ```
+  test.run(|ops| async move {
+      assert!(true);
+  });
+  ```
+- BREAKING: `FnOnce` argument to `DockerTest::run` changed its provided
+  arguments to an owned variant of `DockerOperations`.
+- BREAKING: `DockerOperations.handle()` changed to panicking method, directly
+  returning a `RunningContainer` instead of a `Result`.
 
 ### Removed
-- BREAKING: The ability to set host ip port mapping for each container.
-    There should be no circumstances where using the docker network directly to communicate
-    is insufficient.
+
+- BREAKING: The ability to set host ip port mapping for each container. There
+  should be no circumstances where using the docker network directly to
+  communicate is insufficient.
 
 ## [0.0.4]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,29 +13,29 @@ readme = "README.md"
 documentation = "https://docs.rs/dockertest"
 
 [dependencies]
-anyhow = "1.0.58"
-async-trait = "0.1.56"
-base64 = "0.13.0"
-bollard = "0.13.0"
-dyn-clone = "1.0.6"
-futures = "0.3.21"
+anyhow = "1.0.72"
+async-trait = "0.1.72"
+base64 = "0.21.2"
+bollard = "0.14.0"
+dyn-clone = "1.0.12"
+futures = "0.3.28"
 lazy_static = "1.4.0"
 secrecy = "0.8.0"
-serde = "1.0.137"
-serde_json = "1.0.81"
-thiserror = "1.0.31"
-tokio = { version = "1.19.2", features = ["full"] }
-tracing = "0.1.35"
+serde = "1.0.180"
+serde_json = "1.0.104"
+thiserror = "1.0.44"
+tokio = { version = "1.29.1", features = ["full"] }
+tracing = "0.1.37"
 rand = "0.8.5"
 
 [dev-dependencies]
 access-queue = "1.1.0"
-once_cell = "1.12.0"
-test-log = { version = "0.2.10", default-features = false, features = ["trace"] }
-tracing-subscriber = { version = "0.3.11", default-features = false, features = ["env-filter", "fmt"] }
+once_cell = "1.18.0"
+test-log = { version = "0.2.12", default-features = false, features = ["trace"] }
+tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt"] }
 
 [build-dependencies]
-anyhow = "1.0.58"
+anyhow = "1.0.72"
 
 [features]
 tls = ["bollard/ssl"]

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -675,6 +675,9 @@ impl Composition {
         // Construct options for create container
         let options = Some(CreateContainerOptions {
             name: &self.container_name,
+            // Sets the platform of the server if its multi-platform capable, we might support user
+            // provided values here at a later time.
+            platform: None,
         });
 
         let config = Config::<&str> {

--- a/src/image.rs
+++ b/src/image.rs
@@ -7,6 +7,7 @@ use bollard::{
     Docker,
 };
 
+use base64::{engine::general_purpose, Engine};
 use futures::stream::StreamExt;
 use secrecy::{ExposeSecret, Secret};
 use serde::Deserialize;
@@ -437,7 +438,8 @@ fn resolve_docker_login_auth(address: &str) -> Result<DockerCredentials, String>
     let auth_encoded = entry
         .auth
         .ok_or("expecting 'auth' field to be present from `docker login`")?;
-    let auth_decoded = base64::decode(auth_encoded)
+    let auth_decoded = general_purpose::STANDARD
+        .decode(auth_encoded)
         .map(|s| String::from_utf8_lossy(&s).to_string())
         .map_err(|e| {
             debug!(

--- a/tests/api/static_containers.rs
+++ b/tests/api/static_containers.rs
@@ -62,7 +62,10 @@ async fn test_external_static_container_handle_resolves_correctly_mixed_with_oth
         ),
         ..Default::default()
     };
-    let options = Some(CreateContainerOptions { name: &s1_name });
+    let options = Some(CreateContainerOptions {
+        name: &s1_name,
+        platform: None,
+    });
     let id = client
         .create_container(options, config)
         .await


### PR DESCRIPTION
Updates all dependencies, notable:
* bollard 0.13 -> 0.14
* tokio 1.19 -> 1.29

Depends on: https://github.com/orcalabs/dockertest-rs/pull/4