### PR TITLE
Use Arc over Rc to enable Send/Sync

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -13,8 +13,7 @@ use secrecy::{ExposeSecret, Secret};
 use serde::Deserialize;
 use tracing::{debug, event, trace, Level};
 
-use std::rc::Rc;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 /// Represents a docker `Image`.
 ///
@@ -25,7 +24,7 @@ pub struct Image {
     tag: String,
     source: Option<Source>,
     pull_policy: PullPolicy,
-    id: Rc<RwLock<String>>,
+    id: Arc<RwLock<String>>,
 }
 
 /// Represents the `Source` of an `Image`.
@@ -82,7 +81,7 @@ impl Image {
             tag: "latest".to_string(),
             source: None,
             pull_policy: PullPolicy::IfNotPresent,
-            id: Rc::new(RwLock::new("".to_string())),
+            id: Arc::new(RwLock::new("".to_string())),
         }
     }
 


### PR DESCRIPTION
Arc has a minor theoretical performance penalty compared to Rc which shouldn't matter at this limited scale in any environment capable of running docker.

Arc enables Send/Sync on the affected types which enables more complicated test setups. As an example, https://github.com/serai-dex/serai/pull/494/files uses a multi-network DockerTest via spawning multiple nested DockerTests. While ideally, a per-composition network API would be added, I did not want to go through that time and effort within this library immediately when I could simply perform this hack on my end.