### PR TITLE
refactor: add docker daemon wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "dockertest"
 version = "0.4.0"
-authors = ["Vegard Sandengen <vegard@orcalabs.no>", "Jon Foss Mikalsen <jon@orcalabs.no>"]
+authors = [
+    "Vegard Sandengen <vegard@orcalabs.no>",
+    "Jon Foss Mikalsen <jon@orcalabs.no>",
+]
 edition = "2018"
 license = "MIT"
 description = "A library to control docker containers when running your integration tests."
@@ -27,12 +30,18 @@ thiserror = "1.0.44"
 tokio = { version = "1.29.1", features = ["full"] }
 tracing = "0.1.37"
 rand = "0.8.5"
+bytes = "1.7.1"
 
 [dev-dependencies]
 access-queue = "1.1.0"
 once_cell = "1.18.0"
-test-log = { version = "0.2.12", default-features = false, features = ["trace"] }
-tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt"] }
+test-log = { version = "0.2.12", default-features = false, features = [
+    "trace",
+] }
+tracing-subscriber = { version = "0.3.17", default-features = false, features = [
+    "env-filter",
+    "fmt",
+] }
 
 [build-dependencies]
 anyhow = "1.0.72"

--- a/src/container/running.rs
+++ b/src/container/running.rs
@@ -3,13 +3,11 @@
 use crate::{
     composition::LogOptions,
     container::PendingContainer,
+    docker::Docker,
     waitfor::{wait_for_message, MessageSource},
 };
 
-use bollard::{
-    models::{PortBinding, PortMap},
-    Docker,
-};
+use bollard::models::{PortBinding, PortMap};
 use serde::Serialize;
 
 use std::{

--- a/src/docker/composition.rs
+++ b/src/docker/composition.rs
@@ -1,0 +1,203 @@
+use super::Docker;
+use crate::{
+    composition::Composition, container::CreatedContainer, static_container::STATIC_CONTAINERS,
+    DockerTestError, Network, PendingContainer,
+};
+use bollard::{
+    container::{
+        Config, CreateContainerOptions, InspectContainerOptions, NetworkingConfig,
+        RemoveContainerOptions,
+    },
+    models::HostConfig,
+    service::{EndpointSettings, PortBinding},
+};
+use std::collections::HashMap;
+use tracing::{debug, event, trace, Level};
+
+impl Docker {
+    pub async fn create_container(
+        &self,
+        composition: Composition,
+        network: Option<&str>,
+        network_settings: &Network,
+    ) -> Result<CreatedContainer, DockerTestError> {
+        trace!("evaluating composition: {composition:#?}");
+        if composition.is_static() {
+            STATIC_CONTAINERS
+                .create(composition, self, network, network_settings)
+                .await
+        } else {
+            self.create_container_inner(composition, network)
+                .await
+                .map(CreatedContainer::Pending)
+        }
+    }
+    // Performs container creation, should NOT be called outside of this module or the static
+    // module.
+    // This is only exposed such that the static module can reach it.
+    // TODO: isolate to static mod only
+    pub async fn create_container_inner(
+        &self,
+        composition: Composition,
+        network: Option<&str>,
+    ) -> Result<PendingContainer, DockerTestError> {
+        debug!("creating container: {}", composition.container_name);
+
+        let start_policy_clone = composition.start_policy.clone();
+        let container_name_clone = composition.container_name.clone();
+
+        if !composition.is_static() {
+            // Ensure we can remove the previous container instance, if it somehow still exists.
+            // Only bail on non-recoverable failure.
+            match self
+                .remove_container_if_exists(&composition.container_name)
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => match e {
+                    DockerTestError::Recoverable(_) => {}
+                    _ => return Err(e),
+                },
+            }
+        }
+
+        let image_id = composition.image().retrieved_id();
+        // Additional programming guard.
+        // This Composition cannot be created without an image id, which
+        // is set through `Image::pull`
+        if image_id.is_empty() {
+            return Err(DockerTestError::Processing("`Composition::create()` invoked without populating its image through `Image::pull()`".to_string()));
+        }
+
+        // As we can't return temporary values owned by this closure
+        // we have to first convert our map into a vector of owned strings,
+        // then convert it to a vector of borrowed strings (&str).
+        // There is probably a better way to do this...
+        let envs: Vec<String> = composition
+            .env
+            .iter()
+            .map(|(key, value)| format!("{}={}", key, value))
+            .collect();
+        let envs = envs.iter().map(|s| s.as_ref()).collect();
+        let cmds = composition.cmd.iter().map(|s| s.as_ref()).collect();
+
+        let mut volumes: Vec<String> = Vec::new();
+        for v in composition.bind_mounts.iter() {
+            event!(
+                Level::DEBUG,
+                "creating host_mounted_volume: {} for container {}",
+                v.as_str(),
+                composition.container_name
+            );
+            volumes.push(v.to_string());
+        }
+
+        for v in composition.final_named_volume_names.iter() {
+            event!(
+                Level::DEBUG,
+                "creating named_volume: {} for container {}",
+                &v,
+                composition.container_name
+            );
+            volumes.push(v.to_string());
+        }
+
+        let mut port_map: HashMap<String, Option<Vec<PortBinding>>> = HashMap::new();
+        let mut exposed_ports: HashMap<&str, HashMap<(), ()>> = HashMap::new();
+
+        for (exposed, host) in &composition.port {
+            let dest_port: Vec<PortBinding> = vec![PortBinding {
+                host_ip: Some("127.0.0.1".to_string()),
+                host_port: Some(host.clone()),
+            }];
+            port_map.insert(exposed.to_string(), Some(dest_port));
+            exposed_ports.insert(exposed, HashMap::new());
+        }
+
+        let network_aliases = composition.network_aliases.as_ref();
+        let mut net_config = None;
+
+        // Construct host config
+        let host_config = network.map(|n| HostConfig {
+            network_mode: Some(n.to_string()),
+            binds: Some(volumes),
+            port_bindings: Some(port_map),
+            publish_all_ports: Some(composition.publish_all_ports),
+            privileged: Some(composition.privileged),
+            ..Default::default()
+        });
+
+        if let Some(n) = network {
+            net_config = network_aliases.map(|a| {
+                let mut endpoints = HashMap::new();
+                let settings = EndpointSettings {
+                    aliases: Some(a.to_vec()),
+                    ..Default::default()
+                };
+                endpoints.insert(n, settings);
+                NetworkingConfig {
+                    endpoints_config: endpoints,
+                }
+            });
+        }
+
+        // Construct options for create container
+        let options = Some(CreateContainerOptions {
+            name: &composition.container_name,
+            // Sets the platform of the server if its multi-platform capable, we might support user
+            // provided values here at a later time.
+            platform: None,
+        });
+
+        let config = Config::<&str> {
+            image: Some(&image_id),
+            cmd: Some(cmds),
+            env: Some(envs),
+            networking_config: net_config,
+            host_config,
+            exposed_ports: Some(exposed_ports),
+            ..Default::default()
+        };
+
+        trace!("creating container from options: {options:#?}, config: {config:#?}");
+
+        let container_info = self
+            .client
+            .create_container(options, config)
+            .await
+            .map_err(|e| DockerTestError::Daemon(format!("failed to create container: {}", e)))?;
+
+        let static_management_policy = composition.static_management_policy().clone();
+        Ok(PendingContainer::new(
+            &container_name_clone,
+            container_info.id,
+            composition.handle(),
+            start_policy_clone,
+            composition.wait,
+            self.clone(),
+            static_management_policy,
+            composition.log_options.clone(),
+        ))
+    }
+
+    // Forcefully removes the given container if it exists.
+    async fn remove_container_if_exists(&self, name: &str) -> Result<(), DockerTestError> {
+        self.client
+            .inspect_container(name, None::<InspectContainerOptions>)
+            .await
+            .map_err(|e| DockerTestError::Recoverable(format!("container did not exist: {}", e)))?;
+
+        // We were able to inspect it successfully, it exists.
+        // Therefore, we can simply force remove it.
+        let options = Some(RemoveContainerOptions {
+            force: true,
+            ..Default::default()
+        });
+        self.client
+            .remove_container(name, options)
+            .await
+            .map_err(|e| {
+                DockerTestError::Daemon(format!("failed to remove existing container: {}", e))
+            })
+    }
+}

--- a/src/docker/container.rs
+++ b/src/docker/container.rs
@@ -1,0 +1,334 @@
+use super::Docker;
+use crate::{
+    composition::Composition,
+    container::{CleanupContainer, HostPortMappings},
+    static_container::STATIC_CONTAINERS,
+    waitfor::MessageSource,
+    DockerTestError, PendingContainer, RunningContainer,
+};
+use bollard::{
+    container::{
+        InspectContainerOptions, LogOutput, RemoveContainerOptions, StartContainerOptions,
+        StopContainerOptions,
+    },
+    errors::Error,
+    network::DisconnectNetworkOptions,
+    secret::ContainerInspectResponse,
+};
+use bytes::Bytes;
+use futures::StreamExt;
+use futures::{future::join_all, Stream};
+use std::convert::TryFrom;
+use tracing::{event, Level};
+
+pub struct ContainerInfo {
+    pub ip: std::net::Ipv4Addr,
+    pub ports: HostPortMappings,
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum ContainerState {
+    Empty,
+    Created,
+    Running,
+    Paused,
+    Restarting,
+    Removing,
+    Exited,
+    Dead,
+}
+
+impl From<bollard::secret::ContainerStateStatusEnum> for ContainerState {
+    fn from(value: bollard::secret::ContainerStateStatusEnum) -> Self {
+        match value {
+            bollard::secret::ContainerStateStatusEnum::EMPTY => ContainerState::Empty,
+            bollard::secret::ContainerStateStatusEnum::CREATED => ContainerState::Created,
+            bollard::secret::ContainerStateStatusEnum::RUNNING => ContainerState::Running,
+            bollard::secret::ContainerStateStatusEnum::PAUSED => ContainerState::Paused,
+            bollard::secret::ContainerStateStatusEnum::RESTARTING => ContainerState::Restarting,
+            bollard::secret::ContainerStateStatusEnum::REMOVING => ContainerState::Removing,
+            bollard::secret::ContainerStateStatusEnum::EXITED => ContainerState::Exited,
+            bollard::secret::ContainerStateStatusEnum::DEAD => ContainerState::Dead,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct ContainerLogSource {
+    pub log_stderr: bool,
+    pub log_stdout: bool,
+    pub follow: bool,
+}
+
+impl From<MessageSource> for ContainerLogSource {
+    fn from(value: MessageSource) -> Self {
+        match value {
+            MessageSource::Stdout => ContainerLogSource {
+                log_stdout: true,
+                ..Default::default()
+            },
+            MessageSource::Stderr => ContainerLogSource {
+                log_stderr: true,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+pub struct LogEntry {
+    pub message: Bytes,
+    pub source: MessageSource,
+}
+
+impl Docker {
+    pub async fn container_state(
+        &self,
+        container_name: &str,
+    ) -> Result<Option<ContainerState>, DockerTestError> {
+        Ok(self
+            .client
+            .inspect_container(container_name, None::<InspectContainerOptions>)
+            .await
+            .map_err(|e| {
+                DockerTestError::Daemon(format!("failed to check container state: {e:?}"))
+            })?
+            .state
+            .and_then(|v| v.status.map(|v| v.into())))
+    }
+
+    pub fn container_logs(
+        &self,
+        container_id: &str,
+        source: ContainerLogSource,
+    ) -> impl Stream<Item = Result<LogEntry, DockerTestError>> {
+        let mut log_options = bollard::container::LogsOptions::<String> {
+            follow: true,
+            ..Default::default()
+        };
+
+        if source.log_stderr {
+            log_options.stderr = true;
+        }
+
+        if source.log_stdout {
+            log_options.stdout = true;
+        }
+
+        self.client
+            .logs(container_id, Some(log_options))
+            .filter_map(move |chunk| {
+                let out = match chunk {
+                    Ok(chunk) => match chunk {
+                        LogOutput::StdErr { message } if source.log_stderr => Some(Ok(LogEntry {
+                            message,
+                            source: MessageSource::Stderr,
+                        })),
+                        LogOutput::StdOut { message } if source.log_stdout => Some(Ok(LogEntry {
+                            message,
+                            source: MessageSource::Stdout,
+                        })),
+                        _ => None,
+                    },
+                    Err(e) => Some(Err(DockerTestError::ContainerLogStream(e.to_string()))),
+                };
+
+                futures::future::ready(out)
+            })
+    }
+
+    pub async fn get_container_ip_and_ports(
+        &self,
+        container_id: &str,
+        network_name: &str,
+    ) -> Result<ContainerInfo, DockerTestError> {
+        let details = self
+            .client
+            .inspect_container(container_id, None::<InspectContainerOptions>)
+            .await
+            .map_err(|e| DockerTestError::Daemon(format!("failed to inspect container: {}", e)))?;
+
+        // Get the ip address from the network
+        let container_ip = if let Some(inspected_network) = details
+            .network_settings
+            .as_ref()
+            .unwrap()
+            .networks
+            .as_ref()
+            .unwrap()
+            .get(network_name)
+        {
+            event!(
+                Level::DEBUG,
+                "container ip from inspect: {}",
+                inspected_network.ip_address.as_ref().unwrap()
+            );
+            inspected_network
+                .ip_address
+                .as_ref()
+                .unwrap()
+                .parse::<std::net::Ipv4Addr>()
+                // Exited containers will not have an IP address
+                .unwrap_or_else(|e| {
+                    event!(Level::TRACE, "container ip address failed to parse: {}", e);
+                    std::net::Ipv4Addr::UNSPECIFIED
+                })
+        } else {
+            std::net::Ipv4Addr::UNSPECIFIED
+        };
+
+        let host_ports = if let Some(ports) = details.network_settings.unwrap().ports {
+            event!(
+                Level::DEBUG,
+                "container ports from inspect: {:?}",
+                ports.clone()
+            );
+            HostPortMappings::try_from(ports)
+                .map_err(|e| DockerTestError::HostPort(e.to_string()))?
+        } else {
+            HostPortMappings::default()
+        };
+
+        Ok(ContainerInfo {
+            ip: container_ip,
+            ports: host_ports,
+        })
+    }
+
+    pub async fn start_container(
+        &self,
+        pending: PendingContainer,
+    ) -> Result<RunningContainer, DockerTestError> {
+        if pending.is_static {
+            STATIC_CONTAINERS.start(&pending).await
+        } else {
+            self.start_container_inner(pending).await
+        }
+    }
+
+    // Internal start method should only be invoked from the static mod.
+    // TODO: isolate to static mod only
+    pub async fn start_container_inner(
+        &self,
+        mut pending: PendingContainer,
+    ) -> Result<RunningContainer, DockerTestError> {
+        self.client
+            .start_container(&pending.name, None::<StartContainerOptions<String>>)
+            .await
+            .map_err(|e| match e {
+                Error::DockerResponseServerError {
+                    message,
+                    status_code,
+                } => {
+                    if status_code == 404 {
+                        let json: Result<serde_json::Value, serde_json::error::Error> =
+                            serde_json::from_str(message.as_str());
+                        match json {
+                            Ok(json) => DockerTestError::Startup(format!(
+                                "failed to start container due to `{}`",
+                                json["message"].as_str().unwrap()
+                            )),
+                            Err(e) => DockerTestError::Daemon(format!(
+                                "daemon json response decode failure: {}",
+                                e
+                            )),
+                        }
+                    } else {
+                        DockerTestError::Daemon(format!("failed to start container: {}", message))
+                    }
+                }
+                _ => DockerTestError::Daemon(format!("failed to start container: {}", e)),
+            })?;
+
+        let waitfor = pending.wait.take().unwrap();
+
+        // Issue WaitFor operation
+        let res = waitfor.wait_for_ready(pending);
+        res.await
+    }
+
+    pub async fn stop_containers(&self, containers: &[CleanupContainer]) {
+        join_all(
+            containers
+                .iter()
+                .filter(|c| !c.is_static())
+                .map(|c| {
+                    self.client
+                        .stop_container(&c.id, None::<StopContainerOptions>)
+                })
+                .collect::<Vec<_>>(),
+        )
+        .await;
+    }
+
+    pub async fn remove_containers(&self, containers: &[CleanupContainer]) {
+        let futures = containers
+            .iter()
+            .filter(|c| !c.is_static())
+            .map(|c| {
+                // It's unlikely that anonymous volumes will be used by several containers.
+                // In this case there will be remove errors that it's possible just to ignore
+                // See:
+                // https://github.com/moby/moby/blob/7b9275c0da707b030e62c96b679a976f31f929d3/daemon/mounts.go#L34).
+                let options = Some(RemoveContainerOptions {
+                    force: true,
+                    v: true,
+                    ..Default::default()
+                });
+
+                self.client.remove_container(&c.id, options)
+            })
+            .collect::<Vec<_>>();
+        join_all(futures).await;
+    }
+
+    // TODO: isolate to static mod only
+    pub async fn remove_container(&self, id: &str) {
+        let remove_opts = Some(RemoveContainerOptions {
+            force: true,
+            ..Default::default()
+        });
+
+        if let Err(e) = self.client.remove_container(id, remove_opts).await {
+            event!(Level::ERROR, "failed to remove static container: {}", e);
+        }
+    }
+
+    // TODO: isolate to static mod only
+    pub async fn disconnect_container(&self, container_id: &str, network: &str) {
+        let opts = DisconnectNetworkOptions::<&str> {
+            container: container_id,
+            force: true,
+        };
+        if let Err(e) = self.client.disconnect_network(network, opts).await {
+            event!(
+                Level::ERROR,
+                "unable to remove dockertest-container from network: {}",
+                e
+            );
+        }
+    }
+
+    // TODO: isolate to static mod only
+    pub async fn running_container_from_composition(
+        &self,
+        composition: Composition,
+        container_details: ContainerInspectResponse,
+    ) -> Result<RunningContainer, DockerTestError> {
+        if let Some(id) = container_details.id {
+            Ok(RunningContainer {
+                client: self.clone(),
+                id,
+                name: composition.container_name.clone(),
+                handle: composition.container_name,
+                ip: std::net::Ipv4Addr::UNSPECIFIED,
+                ports: HostPortMappings::default(),
+                is_static: true,
+                log_options: composition.log_options,
+            })
+        } else {
+            Err(DockerTestError::Daemon(
+                "failed to retrieve container id for external container".to_string(),
+            ))
+        }
+    }
+}

--- a/src/docker/image.rs
+++ b/src/docker/image.rs
@@ -1,0 +1,168 @@
+use super::Docker;
+use crate::{DockerTestError, Image, Source};
+use bollard::{
+    auth::DockerCredentials, errors::Error, image::CreateImageOptions, secret::CreateImageInfo,
+};
+use futures::StreamExt;
+use tracing::{debug, event, Level};
+
+impl Docker {
+    /// Pulls the `Image` if neccessary.
+    ///
+    /// This function respects the `Image` Source and PullPolicy settings.
+    pub async fn pull_image(
+        &self,
+        image: &Image,
+        default_source: &Source,
+    ) -> Result<(), DockerTestError> {
+        let pull_source = match &image.source {
+            None => default_source,
+            Some(r) => r,
+        };
+
+        let exists = self.does_image_exist(image).await?;
+
+        if image.should_pull(exists, pull_source)? {
+            let auth = image.resolve_auth(pull_source)?;
+            self.do_pull(image, auth).await?;
+        }
+
+        let image_id = self.get_image_id(image).await?;
+
+        // FIXME: If we encounter a scenario where the image should not be pulled, we need to err
+        // with appropriate information. Currently, it fails with the same error message as
+        // other scenarios.
+        image.set_id(image_id).await;
+        Ok(())
+    }
+
+    /// Checks whether the image exists locally through attempting to inspect it.
+    ///
+    /// If docker daemon communication failed, we will also implicitly return false.
+    async fn does_image_exist(&self, image: &Image) -> Result<bool, DockerTestError> {
+        match self
+            .client
+            .inspect_image(&format!("{}:{}", image.repository, image.tag))
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(e) => match e {
+                Error::DockerResponseServerError {
+                    message: _,
+                    status_code,
+                } => {
+                    if status_code == 404 {
+                        Ok(false)
+                    } else {
+                        Err(DockerTestError::Daemon(e.to_string()))
+                    }
+                }
+                _ => Err(DockerTestError::Daemon(e.to_string())),
+            },
+        }
+    }
+
+    // Pulls the image from its source
+    // NOTE(lint): uncertain how to structure this otherwise
+    #[allow(clippy::match_single_binding)]
+    async fn do_pull(
+        &self,
+        image: &Image,
+        auth: Option<DockerCredentials>,
+    ) -> Result<(), DockerTestError> {
+        debug!("pulling image: {}:{}", image.repository, image.tag);
+        let options = Some(CreateImageOptions::<&str> {
+            from_image: &image.repository,
+            tag: &image.tag,
+            ..Default::default()
+        });
+
+        let mut stream = self.client.create_image(options, None, auth);
+        // This stream will intermittently yield a progress update.
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(intermitten_result) => match intermitten_result {
+                    CreateImageInfo {
+                        id,
+                        error,
+                        error_detail,
+                        status,
+                        progress,
+                        progress_detail,
+                    } => {
+                        if error.is_some() {
+                            event!(
+                                Level::ERROR,
+                                "pull error {} {:?}",
+                                error.clone().unwrap(),
+                                error_detail.unwrap_or_default()
+                            );
+                        } else {
+                            event!(
+                                Level::TRACE,
+                                "pull progress {} {:?} {:?} {:?}",
+                                status.clone().unwrap_or_default(),
+                                id.clone().unwrap_or_default(),
+                                progress.clone().unwrap_or_default(),
+                                progress_detail.clone().unwrap_or_default()
+                            );
+                        }
+                    }
+                },
+                Err(e) => {
+                    let msg = match e {
+                        Error::DockerResponseServerError {
+                            message: _,
+                            status_code,
+                        } => {
+                            if status_code == 404 {
+                                "unknown registry or image".to_string()
+                            } else {
+                                e.to_string()
+                            }
+                        }
+                        _ => e.to_string(),
+                    };
+                    return Err(DockerTestError::Pull {
+                        repository: image.repository.to_string(),
+                        tag: image.tag.to_string(),
+                        error: msg,
+                    });
+                }
+            }
+        }
+
+        // TODO: Verify that we have actually pulled the image.
+        // NOTE: The engine may return a 500 when we unauthorized, but bollard does not give us
+        // this failure. Rather, it just does not provide anthing in the stream.
+        // If a repo is submitted that we do not have access to, and no auth is supplied,
+        // we will no error.
+
+        event!(Level::DEBUG, "successfully pulled image");
+        Ok(())
+    }
+
+    async fn get_image_id(&self, image: &Image) -> Result<String, DockerTestError> {
+        match self
+            .client
+            .inspect_image(&format!("{}:{}", image.repository, image.tag))
+            .await
+        {
+            Ok(details) => Ok(details.id.expect("image did not have an id")),
+            Err(e) => {
+                event!(
+                    Level::TRACE,
+                    "failed to retrieve ID of image: {}, tag: {}, source: {:?} ",
+                    image.repository,
+                    image.tag,
+                    image.source
+                );
+                Err(DockerTestError::Pull {
+                    repository: image.repository.to_string(),
+                    tag: image.tag.to_string(),
+                    error: e.to_string(),
+                })
+            }
+        }
+    }
+}

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,0 +1,24 @@
+use crate::{utils::connect_with_local_or_tls_defaults, DockerTestError};
+
+/// Encapsulates all docker daemon operations
+#[derive(Clone, Debug)]
+pub struct Docker {
+    client: bollard::Docker,
+}
+
+mod composition;
+mod container;
+mod image;
+mod network;
+mod static_container;
+mod volume;
+
+pub use container::{ContainerLogSource, ContainerState, LogEntry};
+
+impl Docker {
+    pub fn new() -> Result<Self, DockerTestError> {
+        let client = connect_with_local_or_tls_defaults().unwrap();
+
+        Ok(Self { client })
+    }
+}

--- a/src/docker/network.rs
+++ b/src/docker/network.rs
@@ -1,0 +1,235 @@
+use std::collections::HashMap;
+
+use bollard::network::{CreateNetworkOptions, DisconnectNetworkOptions, ListNetworksOptions};
+use tracing::{event, Level};
+
+use crate::DockerTestError;
+
+use super::Docker;
+
+impl Docker {
+    pub async fn create_singular_network_impl(
+        &self,
+        network_name: String,
+    ) -> Result<String, DockerTestError> {
+        let config = CreateNetworkOptions {
+            name: network_name.as_str(),
+            ..Default::default()
+        };
+
+        event!(Level::TRACE, "creating singular network");
+
+        match self.client.create_network(config).await {
+            Ok(resp) => match resp.id {
+                Some(id) => Ok(id),
+                None => Err(DockerTestError::Startup(
+                    "failed to get id of singular network".to_string(),
+                )),
+            },
+            Err(e) => {
+                match e {
+                    bollard::errors::Error::DockerResponseServerError {
+                        status_code,
+                        message,
+                    } => {
+                        if status_code == 409 {
+                            // We assume that we got a conflict due to multiple networks with the name
+                            // `dockertest`, and therefore assume that 'existing_dockertest_network' will
+                            // return the conflicting network.
+                            Ok(self
+                                .existing_dockertest_network(&network_name)
+                                .await?
+                                .unwrap())
+                        } else {
+                            Err(DockerTestError::Startup(format!(
+                                "failed to create singular network: {message}",
+                            )))
+                        }
+                    }
+                    _ => Err(DockerTestError::Startup(format!(
+                        "failed to create singular network: {e}"
+                    ))),
+                }
+            }
+        }
+    }
+
+    pub async fn existing_dockertest_network(
+        &self,
+        network_name: &str,
+    ) -> Result<Option<String>, DockerTestError> {
+        let mut filter = HashMap::with_capacity(1);
+        filter.insert("name", vec![network_name]);
+
+        let opts = ListNetworksOptions { filters: filter };
+        let networks = self
+            .client
+            .list_networks(Some(opts))
+            .await
+            .map_err(|e| DockerTestError::Startup(format!("failed to list networks: {e}")))?;
+
+        let mut highest_timestamp: Option<String> = None;
+        let mut highest_timestamp_id: Option<String> = None;
+
+        // We assume id is present on the returned networks
+        for n in networks {
+            if let Some(name) = n.name {
+                if name == network_name {
+                    if let Some(timestamp) = n.created {
+                        if let Some(compare_timestamp) = &highest_timestamp {
+                            if timestamp.as_str() > compare_timestamp.as_str() {
+                                highest_timestamp = Some(timestamp);
+                                highest_timestamp_id = Some(n.id.unwrap());
+                            }
+                        } else {
+                            highest_timestamp = Some(timestamp);
+                            highest_timestamp_id = Some(n.id.unwrap());
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(highest_timestamp_id)
+    }
+
+    pub(crate) async fn create_network(
+        &self,
+        network_name: &str,
+        self_container: Option<&str>,
+    ) -> Result<(), DockerTestError> {
+        let config = CreateNetworkOptions {
+            name: network_name,
+            ..Default::default()
+        };
+
+        event!(Level::TRACE, "creating network {}", network_name);
+        let res = self
+            .client
+            .create_network(config)
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                DockerTestError::Startup(format!("creating docker network failed: {}", e))
+            });
+
+        event!(
+            Level::TRACE,
+            "finished created network with result: {}",
+            res.is_ok()
+        );
+
+        if let Some(id) = self_container {
+            if let Err(e) = self.add_self_to_network(id, network_name).await {
+                if let Err(e) = self.client.remove_network(network_name).await {
+                    event!(
+                        Level::ERROR,
+                        "unable to remove docker network `{}`: {}",
+                        network_name,
+                        e
+                    );
+                }
+                return Err(e);
+            }
+        }
+
+        res
+    }
+
+    /// Make sure we remove the network we have previously created.
+    pub(crate) async fn delete_network(&self, network_name: &str, self_container: Option<&str>) {
+        if let Some(id) = self_container {
+            let opts = DisconnectNetworkOptions::<&str> {
+                container: id,
+                force: true,
+            };
+            if let Err(e) = self.client.disconnect_network(network_name, opts).await {
+                event!(
+                    Level::ERROR,
+                    "unable to remove dockertest-container from network: {}",
+                    e
+                );
+            }
+        }
+
+        if let Err(e) = self.client.remove_network(network_name).await {
+            event!(
+                Level::ERROR,
+                "unable to remove docker network `{}`: {}",
+                network_name,
+                e
+            );
+        }
+    }
+
+    pub(crate) async fn add_self_to_network(
+        &self,
+        container_id: &str,
+        network_name: &str,
+    ) -> Result<(), DockerTestError> {
+        event!(
+            Level::TRACE,
+            "adding dockertest container to created network, container_id: {}, network_id: {}",
+            container_id,
+            network_name,
+        );
+        let opts = bollard::network::ConnectNetworkOptions {
+            container: container_id,
+            endpoint_config: bollard::models::EndpointSettings::default(),
+        };
+
+        self.client
+            .connect_network(network_name, opts)
+            .await
+            .map_err(|e| {
+                DockerTestError::Startup(format!(
+                    "failed to add internal container to dockertest network: {}",
+                    e
+                ))
+            })
+    }
+
+    // TODO: isolate to static mod only
+    pub async fn add_container_to_network(
+        &self,
+        container_id: &str,
+        network: &str,
+    ) -> Result<(), DockerTestError> {
+        let opts = bollard::network::ConnectNetworkOptions {
+            container: container_id,
+            endpoint_config: bollard::models::EndpointSettings::default(),
+        };
+
+        event!(
+            Level::DEBUG,
+            "adding to network: {}, container: {}",
+            network,
+            container_id
+        );
+
+        match self.client.connect_network(network, opts).await {
+            Ok(_) => Ok(()),
+            Err(e) => match e {
+                bollard::errors::Error::DockerResponseServerError {
+                    status_code,
+                    message: _,
+                } => {
+                    // The container was already connected to the network which is what we wanted
+                    // anyway
+                    if status_code == 403 {
+                        Ok(())
+                    } else {
+                        Err(DockerTestError::Startup(format!(
+                            "failed to add static container to dockertest network: {}",
+                            e
+                        )))
+                    }
+                }
+                _ => Err(DockerTestError::Startup(format!(
+                    "failed to add static container to dockertest network: {}",
+                    e
+                ))),
+            },
+        }
+    }
+}

--- a/src/docker/static_container.rs
+++ b/src/docker/static_container.rs
@@ -1,0 +1,115 @@
+use crate::{
+    composition::Composition, static_container::CreateDynamicContainer, DockerTestError, Network,
+    RunningContainer,
+};
+use bollard::{
+    container::{InspectContainerOptions, RemoveContainerOptions},
+    secret::ContainerStateStatusEnum,
+};
+
+use super::Docker;
+
+impl Docker {
+    pub async fn include_static_external_container(
+        &self,
+        composition: Composition,
+        network: Option<&str>,
+        network_mode: &Network,
+    ) -> Result<RunningContainer, DockerTestError> {
+        let details = self
+            .client
+            .inspect_container(&composition.container_name, None::<InspectContainerOptions>)
+            .await
+            .map_err(|e| {
+                DockerTestError::Daemon(format!("failed to inspect external container: {}", e))
+            })?;
+
+        let running = self
+            .running_container_from_composition(composition, details)
+            .await?;
+
+        match network_mode {
+            Network::External(_) => (),
+            // The first to include external containers are responsible for including them in
+            // the singular/isolated network
+            Network::Isolated | Network::Singular => {
+                if let Some(n) = network {
+                    self.add_container_to_network(running.id(), n).await?;
+                }
+            }
+        }
+
+        Ok(running)
+    }
+    pub async fn create_dynamic_container(
+        &self,
+        composition: Composition,
+        network: Option<&str>,
+    ) -> Result<CreateDynamicContainer, DockerTestError> {
+        let details = self
+            .client
+            .inspect_container(&composition.container_name, None::<InspectContainerOptions>)
+            .await;
+
+        match details {
+            Ok(d) => {
+                if let Some(container_state) = &d.state {
+                    if let Some(status) = container_state.status {
+                        if status != ContainerStateStatusEnum::RUNNING {
+                            let options = Some(RemoveContainerOptions {
+                                force: true,
+                                ..Default::default()
+                            });
+                            self.client
+                                .remove_container(&composition.container_name, options)
+                                .await
+                                .map_err(|e| {
+                                    DockerTestError::Daemon(format!(
+                                        "failed to remove existing container: {}",
+                                        e
+                                    ))
+                                })?;
+                        }
+                    }
+                }
+                let running = self
+                    .running_container_from_composition(composition, d)
+                    .await?;
+
+                // Regardless of network mode the first to create a Dynamic container is
+                // responsible for adding it to the network
+                if let Some(n) = network {
+                    self.add_container_to_network(&running.id, n).await?;
+                }
+
+                Ok(CreateDynamicContainer::RunningPrior(running))
+            }
+            Err(e) => match e {
+                bollard::errors::Error::DockerResponseServerError {
+                    message: _,
+                    status_code,
+                } => {
+                    // The container does not exists, we have to create it.
+                    if status_code == 404 {
+                        let pending = self.create_container_inner(composition, network).await?;
+
+                        if let Some(n) = network {
+                            self.add_container_to_network(&pending.id, n).await?;
+                        }
+
+                        Ok(CreateDynamicContainer::Pending(pending))
+                    } else {
+                        Err(DockerTestError::Daemon(format!(
+                            "failed to inspect dynamic container: {}",
+                            e
+                        )))
+                    }
+                }
+                _ => Err(DockerTestError::Daemon(format!(
+                    "failed to inspect dynamic container: {}",
+                    e
+                ))),
+            },
+        }
+    }
+}

--- a/src/docker/volume.rs
+++ b/src/docker/volume.rs
@@ -1,0 +1,21 @@
+use bollard::volume::RemoveVolumeOptions;
+use futures::future::join_all;
+use tracing::{event, Level};
+
+use super::Docker;
+
+impl Docker {
+    pub async fn remove_volumes(&self, volumes: &[String]) {
+        join_all(
+            volumes
+                .iter()
+                .map(|v| {
+                    event!(Level::INFO, "removing named volume: {:?}", &v);
+                    let options = Some(RemoveVolumeOptions { force: true });
+                    self.client.remove_volume(v, options)
+                })
+                .collect::<Vec<_>>(),
+        )
+        .await;
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,4 +28,6 @@ pub enum DockerTestError {
     LogWriteError(String),
     #[error("host port error `{0}`")]
     HostPort(String),
+    #[error("failed to follow container log stream `{0}'")]
+    ContainerLogStream(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@
 
 mod composition;
 mod container;
+mod docker;
 mod dockertest;
 mod engine;
 mod error;

--- a/src/waitfor/nowait.rs
+++ b/src/waitfor/nowait.rs
@@ -22,14 +22,14 @@ impl WaitFor for NoWait {
 #[cfg(test)]
 mod tests {
     use crate::container::PendingContainer;
-    use crate::utils::connect_with_local_or_tls_defaults;
+    use crate::docker::Docker;
     use crate::waitfor::{NoWait, WaitFor};
     use crate::StartPolicy;
 
     // Tests that WaitFor implementation for NoWait
     #[tokio::test]
     async fn test_no_wait_returns_ok() {
-        let client = connect_with_local_or_tls_defaults().unwrap();
+        let client = Docker::new().unwrap();
         let wait = Box::new(NoWait {});
 
         let container_name = "this_is_a_name".to_string();


### PR DESCRIPTION
This PR adds a wrapper around `bollard::Client` with the motivation to centralize all
docker operations to a single location.
Before this PR, we could issue any docker command from anywhere, which seems a bit
messy and hard to control what docker operations we are issuing.

We now check `bollard::ContainerStateStatusEnum` for container states instead of `is_pending` and
`is_running` in our `WaitFor` implementations as this is recommended by the bollard [documentation](https://github.com/fussybeaver/bollard/blob/1be9ccfa0fbd517eda8ed63dea56371428ec67b6/codegen/swagger/src/models.rs#L1165).

It also introduces a small refactoring of our container log parsing to accommodate the
new docker client changes (we need the new `bytes` dependency here to store the log output).

The rest of the changes are just shuffling existing functionality to the new Docker wrapper.