### PR TITLE
Add pause/unpause/kill container api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1.39.3", features = ["full"] }
 tracing = "0.1.40"
 rand = "0.8.5"
 bytes = "1.7.1"
+strum = { version = "0.26.3", features = ["derive"] }
 
 [dev-dependencies]
 access-queue = "1.1.0"

--- a/src/container/pending.rs
+++ b/src/container/pending.rs
@@ -3,7 +3,7 @@
 use crate::{
     composition::{LogOptions, StaticManagementPolicy},
     container::OperationalContainer,
-    docker::Docker,
+    docker::{ContainerState, Docker},
     waitfor::WaitFor,
     DockerTestError, StartPolicy,
 };
@@ -43,6 +43,9 @@ pub struct PendingContainer {
 
     /// Container log options, they are provided by `Composition`.
     pub(crate) log_options: Option<LogOptions>,
+
+    /// The containers' expected state after executing its `WaitFor` implementation.
+    pub(crate) expected_state: ContainerState,
 }
 
 impl PendingContainer {
@@ -64,11 +67,12 @@ impl PendingContainer {
             name: name.to_string(),
             id: id.to_string(),
             handle: handle.to_string(),
-            wait: Some(wait),
             start_policy,
             is_static: static_management_policy.is_some(),
             static_management_policy,
             log_options,
+            expected_state: wait.expected_state(),
+            wait: Some(wait),
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,10 +2,17 @@
 
 use thiserror::Error;
 
+use crate::ContainerState;
+
 /// Public library error conditions.
 #[derive(Error, Debug, PartialEq, Clone, Eq)]
 #[allow(missing_docs)]
 pub enum DockerTestError {
+    #[error("tried to enter container state `{current}` from state `{tried_to_enter}`")]
+    ContainerState {
+        current: ContainerState,
+        tried_to_enter: ContainerState,
+    },
     #[error("docker daemon interaction error `{0}`")]
     Daemon(String),
     #[error("recoverable error condition")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,7 @@ pub mod waitfor;
 
 pub use crate::composition::{LogAction, LogOptions, LogPolicy, LogSource, StartPolicy};
 pub use crate::container::{OperationalContainer, PendingContainer};
+pub use crate::docker::ContainerState;
 pub use crate::dockertest::DockerTest;
 pub use crate::dockertest::Network;
 pub use crate::error::DockerTestError;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -294,6 +294,7 @@ impl Runner {
                 error!("{err}");
             }
         }
+
         self.teardown(engine, result.is_err()).await;
 
         if let Err(option) = result {

--- a/src/waitfor/mod.rs
+++ b/src/waitfor/mod.rs
@@ -2,6 +2,7 @@
 //! and all the default implementations of it.
 
 use crate::container::{OperationalContainer, PendingContainer};
+use crate::docker::ContainerState;
 use crate::DockerTestError;
 
 pub use async_trait::async_trait;
@@ -28,6 +29,14 @@ pub trait WaitFor: Send + Sync + DynClone + std::fmt::Debug {
         &self,
         container: PendingContainer,
     ) -> Result<OperationalContainer, DockerTestError>;
+
+    /// What state the container is expected to be in after completing the `wait_for_ready` method,
+    /// defaulting to the `ContainerState::Running` state.
+    /// NOTE: This is only relevant for the container state api on 'OperationalContainer' (start, stop,
+    /// kill) as we deny certain operations based on the assumed container state.
+    fn expected_state(&self) -> ContainerState {
+        ContainerState::Running
+    }
 }
 
 dyn_clone::clone_trait_object!(WaitFor);

--- a/src/waitfor/status.rs
+++ b/src/waitfor/status.rs
@@ -50,6 +50,10 @@ impl WaitFor for ExitedWait {
         })
         .await
     }
+
+    fn expected_state(&self) -> ContainerState {
+        ContainerState::Exited
+    }
 }
 
 async fn wait_for_container_state(
@@ -75,7 +79,7 @@ async fn wait_for_container_state(
         }
 
         started = if let Ok(c) = client.container_state(&container.name).await {
-            container_state_compare(c.unwrap())
+            container_state_compare(c)
         } else {
             false
         };

--- a/tests/api/container_state.rs
+++ b/tests/api/container_state.rs
@@ -1,0 +1,155 @@
+use crate::helper::TestHelper;
+use dockertest::waitfor::RunningWait;
+use dockertest::{ContainerState, DockerTest, Source, TestBodySpecification};
+use test_log::test;
+
+#[test]
+fn test_pause_container() {
+    let source = Source::DockerHub;
+    let mut test = DockerTest::new().with_default_source(source);
+
+    let repo = "luca3m/sleep";
+    let sleep_container =
+        TestBodySpecification::with_repository(repo).set_wait_for(Box::new(RunningWait {
+            max_checks: 10,
+            check_interval: 6,
+        }));
+
+    test.provide_container(sleep_container);
+
+    let helper = TestHelper::new();
+
+    test.run(|ops| async move {
+        let handle = ops.handle(repo);
+
+        handle.pause().await;
+
+        let actual_state = helper.container_state(handle.name()).await;
+
+        assert_eq!(actual_state, ContainerState::Paused);
+    });
+}
+
+#[test]
+fn test_kill_container() {
+    let source = Source::DockerHub;
+    let mut test = DockerTest::new().with_default_source(source);
+
+    let repo = "luca3m/sleep";
+    let sleep_container =
+        TestBodySpecification::with_repository(repo).set_wait_for(Box::new(RunningWait {
+            max_checks: 10,
+            check_interval: 6,
+        }));
+
+    test.provide_container(sleep_container);
+
+    let helper = TestHelper::new();
+
+    test.run(|ops| async move {
+        let handle = ops.handle(repo);
+
+        handle.kill().await;
+
+        let actual_state = helper.container_state(handle.name()).await;
+
+        assert_eq!(actual_state, ContainerState::Exited);
+    });
+}
+
+#[test]
+fn test_start_container() {
+    let source = Source::DockerHub;
+    let mut test = DockerTest::new().with_default_source(source);
+
+    let repo = "luca3m/sleep";
+    let sleep_container =
+        TestBodySpecification::with_repository(repo).set_wait_for(Box::new(RunningWait {
+            max_checks: 10,
+            check_interval: 6,
+        }));
+
+    test.provide_container(sleep_container);
+
+    let helper = TestHelper::new();
+
+    test.run(|ops| async move {
+        let handle = ops.handle(repo);
+
+        handle.pause().await;
+        let actual_state = helper.container_state(handle.name()).await;
+        assert_eq!(actual_state, ContainerState::Paused);
+
+        handle.unpause().await;
+        let actual_state = helper.container_state(handle.name()).await;
+        assert_eq!(actual_state, ContainerState::Running);
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_double_pausing_container_panics() {
+    let source = Source::DockerHub;
+    let mut test = DockerTest::new().with_default_source(source);
+
+    let repo = "luca3m/sleep";
+    let sleep_container =
+        TestBodySpecification::with_repository(repo).set_wait_for(Box::new(RunningWait {
+            max_checks: 10,
+            check_interval: 6,
+        }));
+
+    test.provide_container(sleep_container);
+
+    test.run(|ops| async move {
+        let handle = ops.handle(repo);
+
+        handle.pause().await;
+        handle.pause().await;
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_double_killing_container_panics() {
+    let source = Source::DockerHub;
+    let mut test = DockerTest::new().with_default_source(source);
+
+    let repo = "luca3m/sleep";
+    let sleep_container =
+        TestBodySpecification::with_repository(repo).set_wait_for(Box::new(RunningWait {
+            max_checks: 10,
+            check_interval: 6,
+        }));
+
+    test.provide_container(sleep_container);
+
+    test.run(|ops| async move {
+        let handle = ops.handle(repo);
+
+        handle.kill().await;
+        handle.kill().await;
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_unpausing_non_paused_container_panics() {
+    let source = Source::DockerHub;
+    let mut test = DockerTest::new().with_default_source(source);
+
+    let repo = "luca3m/sleep";
+    let sleep_container =
+        TestBodySpecification::with_repository(repo).set_wait_for(Box::new(RunningWait {
+            max_checks: 10,
+            check_interval: 6,
+        }));
+
+    test.provide_container(sleep_container);
+
+    test.run(|ops| async move {
+        let handle = ops.handle(repo);
+
+        handle.unpause().await;
+    });
+}

--- a/tests/api/helper.rs
+++ b/tests/api/helper.rs
@@ -1,5 +1,5 @@
-use bollard::{secret::ContainerStateStatusEnum, Docker};
-use dockertest::{utils::connect_with_local_or_tls_defaults, OperationalContainer};
+use bollard::{container::InspectContainerOptions, secret::ContainerStateStatusEnum, Docker};
+use dockertest::{utils::connect_with_local_or_tls_defaults, ContainerState, OperationalContainer};
 
 pub struct TestHelper {
     client: Docker,
@@ -11,6 +11,19 @@ impl TestHelper {
             client: connect_with_local_or_tls_defaults().unwrap(),
         }
     }
+
+    pub async fn container_state(&self, name: &str) -> ContainerState {
+        self.client
+            .inspect_container(name, None::<InspectContainerOptions>)
+            .await
+            .unwrap()
+            .state
+            .unwrap()
+            .status
+            .unwrap()
+            .into()
+    }
+
     pub async fn env_value(&self, handle: &OperationalContainer, env: &str) -> Option<String> {
         self.client
             .inspect_container(handle.name(), None)

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -2,6 +2,7 @@
 #![deny(rust_2018_idioms)]
 
 mod annotation_test_runtime;
+mod container_state;
 mod helper;
 mod integration_test;
 mod message;


### PR DESCRIPTION
Adds the possibility to pause/unpause/kill containers from within the test body.
We panic on an invalid combination of these methods, e.g. calling pause twice on a container.

The initial container state is inferred through the new method added on the `WaitFor` trait, `expected_state`.
The default implementation expects the container to be in a `Running` state.

Instead of leaving state inference to the `WaitFor` trait we could inspect containers after completing their `WaitFor` implementation and using their actual state instead.
This costs us an extra inspect per container, and may lead to unexpected situations if the container exits unexpectedly.
We could combine both and assert that `expected_state` returns the same state as the actual container state, but this
becomes surprising with the `Message` wait for on short lived containers that simply echoes something to `stdout` as they will always be in a exited after the `WaitFor` completes.

Open to other design ideas for container state inference.
 
Depends on: https://github.com/orcalabs/dockertest-rs/pull/17